### PR TITLE
fix: this dependabot configuration does not set a co... in...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily" # Check for updates daily
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
Address high severity security finding in `.github/dependabot.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown` |
| **File** | `.github/dependabot.yml:8` |
| **Assessment** | Pattern match — needs manual review |

**Description**: This Dependabot configuration does not set a cooldown period. Newly published packages can be malicious or unstable. Add a `cooldown` block with `default-days: 7` to each `package-ecosystem` entry under `updates` to wait 7 days before proposing updates to newly published package versions. Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown

## Evidence

**Scanner confirmation**: semgrep rule `package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown` matched this pattern as package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `.github/dependabot.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
